### PR TITLE
Ensure user can set a new featured image if image has been deleted.

### DIFF
--- a/network-media-library.php
+++ b/network-media-library.php
@@ -160,11 +160,18 @@ function admin_post_thumbnail_html( string $content, $post_id, $thumbnail_id ) :
 	$switched = false;
 	restore_current_blog();
 
-	$post             = get_post( $post_id );
-	$post_type_object = get_post_type_object( $post->post_type );
+	$post              = get_post( $post_id );
+	$post_type_object  = get_post_type_object( $post->post_type );
+	$has_thumbnail_url = get_the_post_thumbnail_url( $post_id ) !== false;
 
-	$search  = '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail"></a></p>';
-	$replace = '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail">' . esc_html( $post_type_object->labels->remove_featured_image ) . '</a></p>';
+	if ( $has_thumbnail_url === false ) {
+		$search  = 'class="thickbox"></a>';
+		$replace = 'class="thickbox">' . esc_html( $post_type_object->labels->set_featured_image ) . '</a>';
+	} else {
+		$search  = '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail"></a></p>';
+		$replace = '<p class="hide-if-no-js"><a href="#" id="remove-post-thumbnail">' . esc_html( $post_type_object->labels->remove_featured_image ) . '</a></p>';
+	}
+
 	$content = str_replace( $search, $replace, $content );
 
 	return $content;


### PR DESCRIPTION
Fixes #29

This applies the code from
https://github.com/humanmade/network-media-library/issues/29#issuecomment-434344263
to fix the issue where a media item has been deleted from the central
library but is referenced from another site.

It should be noted that this is masking over the problem a little which
is that when a media item is deleted for the site in which it's deleted
on it will also delete all the metadata links to that media item (see https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L5425) this obviously doesn't do the same for all sites in the network. Therefore a more complete fix for this would be to hook into [delete_attachment](https://github.com/WordPress/WordPress/blob/master/wp-includes/post.php#L5419) looping over each site in the network and deleting the appropriate metadata.