### PR TITLE
Use return_format on ACFs within the media site.

### DIFF
--- a/network-media-library.php
+++ b/network-media-library.php
@@ -432,7 +432,24 @@ class ACF_Value_Filter {
 	}
 
 	/**
-	 * Fiters the return value when using field retrieval functions in Advanced Custom Fields.
+	 * Transforms an Advanced Custom Field into the format specified return format.
+	 *
+	 * @param string $return_format The expected format to be returned - specified in the ACF field.
+	 * @param mixed  $value         The field value.
+	 * @return mixed The ACF field's value in the new format.
+	 */
+	private function transform_acf_to_return_format( $return_format, $value ) {
+		switch ( $return_format ) {
+			case 'url':
+				return wp_get_attachment_url( $value );
+			case 'array':
+				return acf_get_attachment( $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Filters the return value when using field retrieval functions in Advanced Custom Fields.
 	 *
 	 * @param mixed      $value   The field value.
 	 * @param int|string $post_id The post ID for this value.
@@ -444,17 +461,10 @@ class ACF_Value_Filter {
 
 		if ( ! is_media_site() && ! is_admin() ) {
 			switch_to_media_site();
-
-			switch ( $field['return_format'] ) {
-				case 'url':
-					$image = wp_get_attachment_url( $value );
-					break;
-				case 'array':
-					$image = acf_get_attachment( $value );
-					break;
-			}
-
+			$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
 			restore_current_blog();
+		} else {
+			$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
 		}
 
 		$this->value = $image;
@@ -463,7 +473,7 @@ class ACF_Value_Filter {
 	}
 
 	/**
-	 * Fiters the optionally formatted value when using field retrieval functions in Advanced Custom Fields.
+	 * Filters the optionally formatted value when using field retrieval functions in Advanced Custom Fields.
 	 *
 	 * @param mixed      $value   The field value.
 	 * @param int|string $post_id The post ID for this value.

--- a/network-media-library.php
+++ b/network-media-library.php
@@ -459,12 +459,14 @@ class ACF_Value_Filter {
 	public function filter_acf_attachment_load_value( $value, $post_id, array $field ) {
 		$image = $value;
 
-		if ( ! is_media_site() && ! is_admin() ) {
-			switch_to_media_site();
-			$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
-			restore_current_blog();
-		} else {
-			$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
+		if ( ! is_admin() ) {
+			if ( ! is_media_site() ) {
+				switch_to_media_site();
+				$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
+				restore_current_blog();
+			} else {
+				$image = $this->transform_acf_to_return_format( $field['return_format'], $value );
+			}
 		}
 
 		$this->value = $image;


### PR DESCRIPTION
This commit will fix issue #51.

The issue is that the media site also needs to respect the
Advanced Custom Fields' return format. In the code we ask it to
kindly skip the formatting of the ACF if we are in the media site.
The fix is to allow the ACF to be formatted, independent of which
site or context the filter is run from.