### PR TITLE
Fix a bug on return format

### DIFF
--- a/network-media-library.php
+++ b/network-media-library.php
@@ -442,7 +442,7 @@ class ACF_Value_Filter {
 	public function filter_acf_attachment_load_value( $value, $post_id, array $field ) {
 		$image = $value;
 
-		if ( ! is_media_site() && ! is_admin() ) {
+		if ( ! is_admin() ) {
 			switch_to_media_site();
 
 			switch ( $field['return_format'] ) {


### PR DESCRIPTION
Network-media-library ignores the return format on the central media site.